### PR TITLE
Add randomart editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,13 @@
 This is the web application of ssh randomart editor.
 
 You can paint whatever you want, ignoring the drunken bishop, Peter's dreamy movement.
+
+## Running locally
+Open `index.html` in your favorite web browser. No build step or additional dependencies are required.
+
+## GitHub Pages
+If this repository is published with GitHub Pages, you can access the editor at:
+```
+https://&lt;your-github-username&gt;.github.io/ssh_randomart_editor/
+```
+Replace `&lt;your-github-username&gt;` with your actual GitHub username.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>SSH Randomart Editor</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <h1>SSH Randomart Editor</h1>
+    <div id="grid-container"></div>
+    <div class="controls">
+        <button id="clear">Clear</button>
+        <button id="export">Export</button>
+    </div>
+    <pre id="output"></pre>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,50 @@
+const chars = [' ', '.', 'o', '+', '=', '*', 'B', 'O', 'X', '@', '%', '&', '#', '/', '^', 'S', 'E'];
+const width = 17;
+const height = 9;
+
+function createGrid() {
+    const container = document.getElementById('grid-container');
+    const table = document.createElement('table');
+
+    for (let y = 0; y < height; y++) {
+        const tr = document.createElement('tr');
+        for (let x = 0; x < width; x++) {
+            const td = document.createElement('td');
+            td.textContent = ' ';
+            td.dataset.index = 0;
+            td.addEventListener('click', () => {
+                const idx = (parseInt(td.dataset.index, 10) + 1) % chars.length;
+                td.dataset.index = idx;
+                td.textContent = chars[idx];
+            });
+            tr.appendChild(td);
+        }
+        table.appendChild(tr);
+    }
+    container.appendChild(table);
+}
+
+function clearGrid() {
+    document.querySelectorAll('#grid-container td').forEach(td => {
+        td.textContent = ' ';
+        td.dataset.index = 0;
+    });
+    document.getElementById('output').textContent = '';
+}
+
+function exportArt() {
+    let art = '';
+    const rows = document.querySelectorAll('#grid-container tr');
+    rows.forEach(row => {
+        row.querySelectorAll('td').forEach(td => {
+            art += td.textContent;
+        });
+        art += '\n';
+    });
+    document.getElementById('output').textContent = art;
+}
+
+document.getElementById('clear').addEventListener('click', clearGrid);
+document.getElementById('export').addEventListener('click', exportArt);
+
+createGrid();

--- a/style.css
+++ b/style.css
@@ -1,0 +1,31 @@
+body {
+    font-family: monospace;
+    text-align: center;
+    margin: 20px;
+}
+
+#grid-container {
+    display: inline-block;
+    margin-bottom: 10px;
+}
+
+table {
+    border-collapse: collapse;
+}
+
+td {
+    width: 20px;
+    height: 20px;
+    border: 1px solid #ccc;
+    cursor: pointer;
+}
+
+.controls {
+    margin-bottom: 10px;
+}
+
+#output {
+    white-space: pre;
+    text-align: left;
+    display: inline-block;
+}


### PR DESCRIPTION
## Summary
- implement web-based SSH randomart editor
- add simple styling and scripting
- document how to run locally and via GitHub Pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685d587ca38c83249e2587669633ca10