### PR TITLE
Customize header text

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 This is the web application of ssh randomart editor.
 
 You can paint whatever you want, ignoring the drunken bishop, Peter's dreamy movement.
+Use the text field above the grid to customize the nine character header that appears in the exported randomart.
 
 ## Running locally
 Open `index.html` in your favorite web browser. No build step or additional dependencies are required.

--- a/index.html
+++ b/index.html
@@ -10,6 +10,8 @@
 <body>
     <h1>SSH Randomart Editor</h1>
     <div id="palette" class="palette"></div>
+    <label for="header-input">Header text (9 chars): </label>
+    <input id="header-input" type="text" maxlength="9" value="ABCDEFGHI">
     <div id="grid-container"></div>
     <div class="controls">
         <button id="clear">Clear</button>

--- a/script.js
+++ b/script.js
@@ -4,12 +4,17 @@ const drawHeight = 9;
 const width = drawWidth + 2;
 const height = drawHeight + 2;
 
+let headerInput = null;
+
 let currentChar = chars[1];
 let isPainting = false;
 
 function createGrid() {
     const container = document.getElementById('grid-container');
     const table = document.createElement('table');
+
+    const headerText = (headerInput && headerInput.value) ? headerInput.value : 'ABCDEFGHI';
+    const headerRow = (`+--[${headerText.padEnd(9, ' ').slice(0, 9)}]----+`).split('');
 
     for (let y = 0; y < height; y++) {
         const tr = document.createElement('tr');
@@ -18,10 +23,13 @@ function createGrid() {
             let editable = false;
             let ch = ' ';
 
-            if ((y === 0 || y === height - 1) && (x === 0 || x === width - 1)) {
+            if (y === 0) {
+                ch = headerRow[x];
+                td.classList.add('border');
+            } else if (y === height - 1 && (x === 0 || x === width - 1)) {
                 ch = '+';
                 td.classList.add('border');
-            } else if (y === 0 || y === height - 1) {
+            } else if (y === height - 1) {
                 ch = '-';
                 td.classList.add('border');
             } else if (x === 0 || x === width - 1) {
@@ -80,6 +88,15 @@ function exportArt() {
     document.getElementById('output').textContent = art;
 }
 
+function updateHeader() {
+    const headerText = headerInput.value.padEnd(9, ' ').slice(0, 9);
+    const headerRow = `+--[${headerText}]----+`;
+    const cells = document.querySelectorAll('#grid-container tr:first-child td');
+    cells.forEach((td, i) => {
+        td.textContent = headerRow[i] || ' ';
+    });
+}
+
 function createPalette() {
     const palette = document.getElementById('palette');
     chars.forEach(ch => {
@@ -97,8 +114,11 @@ function createPalette() {
     }
 }
 
+headerInput = document.getElementById('header-input');
 document.getElementById('clear').addEventListener('click', clearGrid);
 document.getElementById('export').addEventListener('click', exportArt);
+headerInput.addEventListener('input', updateHeader);
 
 createPalette();
 createGrid();
+updateHeader();

--- a/style.css
+++ b/style.css
@@ -14,7 +14,7 @@ table {
 }
 
 td {
-    width: 20px;
+    width: 12px;
     height: 20px;
     border: 1px solid #ccc;
     cursor: pointer;


### PR DESCRIPTION
## Summary
- allow editing the 9 character header
- make the editor cells narrower

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685d648a9dfc8324b3c1049ab30032e0