### PR TITLE
Fix centering of header input and grid

### DIFF
--- a/style.css
+++ b/style.css
@@ -5,8 +5,8 @@ body {
 }
 
 #grid-container {
-    display: inline-block;
-    margin-bottom: 10px;
+    display: block;
+    margin: 0 auto 10px;
 }
 
 table {
@@ -30,8 +30,8 @@ td.border {
 }
 
 #header-container {
-    display: inline-block;
-    margin-bottom: 10px;
+    display: block;
+    margin: 0 auto 10px;
 }
 
 .palette button {


### PR DESCRIPTION
## Summary
- adjust CSS so the header input and grid are centered independently

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6860c9d48b448324b430bd062b82ab01