### PR TITLE
Refine export view and gallery captions

### DIFF
--- a/gallery_arts.js
+++ b/gallery_arts.js
@@ -11,7 +11,8 @@ const galleryArts = [
 |          . o.o  |
 |             ..  |
 +----[SHA256]-----+`,
-    author: 'Alice'
+    author: 'Alice',
+    caption: "The Alice's randomart image is:"
   },
   {
     art: `+---[RSA 3072]----+
@@ -25,7 +26,8 @@ const galleryArts = [
 |      .o=o....o  |
 |        o+. o+   |
 +----[SHA256]-----+`,
-    author: 'Bob'
+    author: 'Bob',
+    caption: "The Bob's randomart image is:"
   },
   {
     art: `+---[RSA 3072]----+
@@ -39,7 +41,8 @@ const galleryArts = [
 |         E       |
 |                 |
 +----[SHA256]-----+`,
-    author: 'Carol'
+    author: 'Carol',
+    caption: "The Carol's randomart image is:"
   },
   {
     art: `+---[RSA 3072]----+
@@ -53,7 +56,8 @@ const galleryArts = [
 |  .  . o *       |
 |   ..  .=oo      |
 +----[SHA256]-----+`,
-    author: 'Dave'
+    author: 'Dave',
+    caption: "The Dave's randomart image is:"
   },
   {
     art: `+---[RSA 3072]----+
@@ -67,6 +71,7 @@ const galleryArts = [
 |        .        |
 |                 |
 +----[SHA256]-----+`,
-    author: 'Eve'
+    author: 'Eve',
+    caption: "The Eve's randomart image is:"
   }
 ];

--- a/index.html
+++ b/index.html
@@ -17,7 +17,6 @@
     <div id="caption-input-container">
         The <input id="caption-input" type="text" maxlength="12">'s randomart image is:
     </div>
-    <div id="caption-display"></div>
     <div id="grid-container"></div>
     <div class="controls">
         <button id="clear">Clear</button>

--- a/script.js
+++ b/script.js
@@ -104,11 +104,6 @@ function updateHeader() {
     });
 }
 
-function updateCaption() {
-    const name = captionInput.value.slice(0, 12);
-    const captionEl = document.getElementById('caption-display');
-    captionEl.textContent = name ? `The ${name}'s randomart image is:` : 'The randomart image is:';
-}
 
 function createPalette() {
     const palette = document.getElementById('palette');
@@ -147,7 +142,7 @@ function loadGallery() {
 
         const caption = document.createElement('div');
         caption.className = 'gallery-caption';
-        caption.textContent = `The ${galleryArts[idx].author}'s randomart image is:`;
+        caption.textContent = galleryArts[idx].caption || `The ${galleryArts[idx].author}'s randomart image is:`;
         item.appendChild(caption);
 
         const pre = document.createElement('pre');
@@ -169,10 +164,8 @@ captionInput = document.getElementById('caption-input');
 document.getElementById('clear').addEventListener('click', clearGrid);
 document.getElementById('export').addEventListener('click', exportArt);
 headerInput.addEventListener('input', updateHeader);
-captionInput.addEventListener('input', updateCaption);
 
 createPalette();
 createGrid();
 updateHeader();
-updateCaption();
 loadGallery();

--- a/style.css
+++ b/style.css
@@ -70,7 +70,7 @@ td.border {
 
 #output {
     white-space: pre;
-    text-align: left;
+    text-align: center;
     display: inline-block;
 }
 


### PR DESCRIPTION
## Summary
- remove caption preview element
- center output text
- save randomart captions with each gallery entry
- read saved captions when showing gallery

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686145155e108324a91eae956a94034b